### PR TITLE
for all products: qty + price should be on same row with product's name (bundle product only has price)

### DIFF
--- a/src/app/modules/+pos/view/default/sales/receipt.component.html
+++ b/src/app/modules/+pos/view/default/sales/receipt.component.html
@@ -56,13 +56,10 @@
         <tbody *ngFor="let item of getOrder()['items'];trackBy:trackById;let last = last;let index = index"
                [ngClass]="{last: index == last}">
         <tr *ngIf="!checkIsCustomSales(item)">
-          <td colspan="2" class="c-left"><h4>{{item['name']}}</h4></td>
-          <td class="c-right">
+          <td class="c-left"><h4>{{item['name']}}</h4></td>
+          <td  *ngIf="!isBundleProduct(item)">{{!checkDecimalsQtyItems(item) ? item['qty_ordered'] : item['qty_ordered'] | number :'1.2-2'}}</td>
+          <td *ngIf="isBundleProduct(item)" class="c-right">
           </td>
-        </tr>
-        <tr *ngIf="checkIsCustomSales(item)">
-          <td class="c-left"><h4>{{item['buy_request']['custom_sale']['name']}}</h4></td>
-          <td>{{!checkDecimalsQtyItems(item) ? item['qty_ordered'] : item['qty_ordered'] | number :'1.2-2'}}</td>
           <td class="c-right" *ngIf="receiptState.salesReceipt.typePrint === 'receipt'">
             <h4>
               {{(getReceiptSetting()['row_total_incl_tax'] == '1' ? item['row_total_incl_tax'] : item['row_total']) | priceFormat}}
@@ -70,7 +67,12 @@
           </td>
         </tr>
         <tr *ngIf="!checkIsCustomSales(item)">
-          <td class="c-left">SKU: {{item['sku']}}</td>
+          <td colspan="2" class="c-left">SKU: {{item['sku']}}</td>
+          <td class="c-right">
+          </td>
+        </tr>
+        <tr *ngIf="checkIsCustomSales(item)">
+          <td class="c-left"><h4>{{item['buy_request']['custom_sale']['name']}}</h4></td>
           <td>{{!checkDecimalsQtyItems(item) ? item['qty_ordered'] : item['qty_ordered'] | number :'1.2-2'}}</td>
           <td class="c-right" *ngIf="receiptState.salesReceipt.typePrint === 'receipt'">
             <h4>

--- a/src/app/modules/+pos/view/default/sales/receipt.component.ts
+++ b/src/app/modules/+pos/view/default/sales/receipt.component.ts
@@ -110,6 +110,14 @@ export class PosDefaultSalesReceiptComponent extends AbstractSubscriptionCompone
     return this._data['productOptions']['configurableOption'][item['id']];
   }
   
+  // FIX XRT 1318 : remove qty for bundle father row
+  isBundleProduct(item) {
+    if (item['type_id'] === 'bundle') {
+      return true;
+    }
+    return false;
+  }
+
   getBundleChildren(item) {
     if (item['type_id'] === 'bundle' && _.isArray(item['children'])) {
       this._data['productOptions']['bundleChildren'][item['id']] = item['children'];


### PR DESCRIPTION


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
