### PR TITLE
FIX xrt 1560

### DIFF
--- a/src/app/modules/+pos/view/default/sales/checkout/popup/product-detail/bundle-options.component.ts
+++ b/src/app/modules/+pos/view/default/sales/checkout/popup/product-detail/bundle-options.component.ts
@@ -76,6 +76,14 @@ export class PosDefaultSalesCheckoutPopupProductDetailBundleOptionsComponent ext
             return false;
           }
         });
+      } else {
+        // FIx 1560 : refactor status change QTY when view detail item in cart
+        _.forEach(this.option['selections'], (selection) => {
+          if (this._bundle_option_qty[this.option['option_id']] == parseFloat(selection['selection_qty'])
+              && this._bundle_option[this.option['option_id']] == selection['selection_id']) {
+            this._bundleProperty.canChangeQty = selection['selection_can_change_qty'] === '1';
+          }
+        });
       }
     }
     this.updateBundleData();


### PR DESCRIPTION
If "User Defined" box is not checked, user shouldn't be able to edit  qty in cart

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
