### PR TITLE
Refund/Exchange - Order ID of exchange order is increased by 2

### DIFF
--- a/src/app/modules/+pos/R/config/config.effects.ts
+++ b/src/app/modules/+pos/R/config/config.effects.ts
@@ -48,8 +48,14 @@ export class PosConfigEffects {
                                      .withLatestFrom(this.store$.select('general'),
                                                      ([action, entitiesState], generalState) => [action, entitiesState, generalState])
                                      .flatMap(([action, configState, generalState]) => {
-                                       const orderCount  = (configState as PosConfigState).orderCount;
+                                       const orderCount   = (configState as PosConfigState).orderCount;
+                                       const saveOffline  = (action as Action).payload['saveOffline'];
+                                       const orderOffline = (action as Action).payload['orderOffline'];
+                                       
                                        let newOrderCount = Object.assign({}, {...orderCount}, {order_count: parseInt(orderCount['order_count']) + 1});
+                                       if (orderOffline === null && saveOffline === false) {
+                                        newOrderCount = Object.assign({}, {...orderCount}, {order_count: parseInt(orderCount['order_count'])});
+                                       }
     
                                        return Observable.fromPromise(this.configService.createNewOrderCount(<any>generalState, newOrderCount))
                                                         .map((_count) => {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
